### PR TITLE
Attempt a Starlark module for configuration

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
-freebsd_instance:
-  image: freebsd-12-2-release-amd64
 task:
-  name: FreeBSD
+  name: Julia on FreeBSD
+  freebsd_instance:
+    image: freebsd-12-2-release-amd64
   env:
     matrix:
       - JULIA_VERSION: 1.6
@@ -16,3 +16,8 @@ task:
     - cirrusjl test
   coverage_script:
     - cirrusjl coverage codecov coveralls
+task:
+  name: Starlark setup
+  container:
+    image: gcr.io/cirrus-ci-community/cirrus-cli:latest
+  script: cirrus internal test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,21 +1,21 @@
-task:
-  name: Julia on FreeBSD
-  freebsd_instance:
-    image: freebsd-12-2-release-amd64
-  env:
-    matrix:
-      - JULIA_VERSION: 1.6
-      - JULIA_VERSION: 1
-      - JULIA_VERSION: nightly
-  allow_failures: $JULIA_VERSION == 'nightly'
-  install_script:
-    - sh bin/install.sh
-  build_script:
-    - cirrusjl build
-  test_script:
-    - cirrusjl test
-  coverage_script:
-    - cirrusjl coverage codecov coveralls
+#task:
+#  name: Julia on FreeBSD
+#  freebsd_instance:
+#    image: freebsd-12-2-release-amd64
+#  env:
+#    matrix:
+#      - JULIA_VERSION: 1.6
+#      - JULIA_VERSION: 1
+#      - JULIA_VERSION: nightly
+#  allow_failures: $JULIA_VERSION == 'nightly'
+#  install_script:
+#    - sh bin/install.sh
+#  build_script:
+#    - cirrusjl build
+#  test_script:
+#    - cirrusjl test
+#  coverage_script:
+#    - cirrusjl coverage codecov coveralls
 task:
   name: Starlark setup
   container:

--- a/lib.star
+++ b/lib.star
@@ -1,0 +1,37 @@
+load("cirrus", environ="env")
+load("github.com/cirrus-modules/helpers", "powershell", "script", "task")
+
+def cirrusjl_install():
+    base = "https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin"
+    os = environ["CIRRUS_OS"]
+    if os == "windows":
+        file = base + "/install.ps1"
+        cmd = "iex ((New-Object System.Net.WebClient).DownloadString('%s'))" % file
+        return powershell("install", cmd)
+    file = base + "/install.sh"
+    if os == "darwin":
+        download = "curl " + file
+    elif os == "freebsd":
+        download = "fetch %s -o -" % file
+    else:
+        download = "wget %s -q -O-" % file
+    cmd = "sh -c \"$(%s)\"" % download
+    return script("install", cmd)
+
+def julia_instructions(coverage=None):
+    steps = [cirrusjl_install(),
+             script("build", "cirrusjl build"),
+             script("test", "cirrusjl test")]
+    if coverage:
+        steps.append(script("coverage", "cirrusjl coverage %s" % coverage))
+    return steps
+
+def julia_tasks(versions, instances, env={}, coverage=None, allow_failures=None):
+    tasks = []
+    instructions = julia_instructions(coverage=coverage)
+    for instance in instances:
+        for version in versions:
+            v = {"JULIA_VERSION": version}.update(env)
+            t = task(name="", instance=instance, instructions=instructions, env=v)
+            tasks.append(t)
+    return tasks

--- a/lib.star
+++ b/lib.star
@@ -1,25 +1,38 @@
 load("cirrus", environ="env")
 load("github.com/cirrus-modules/helpers", "powershell", "script", "task")
 
-def cirrusjl_install():
+def _os_from_instance(instance):
+    # Instances are `dict`s formatted as `{ type: descriptors }` where `type` is
+    # one of Cirrus' predefined execution environment names
+    if instance.get("container") or instance.get("arm_container"):
+        return "Linux"
+    elif instance.get("macos_instance"):
+        return "macOS"
+    elif instance.get("freebsd_instance"):
+        return "FreeBSD"
+    elif instance.get("windows_container"):
+        return "Windows"
+    else:
+        return "Unknown OS"
+
+def cirrusjl_install(os):
     base = "https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin"
-    os = environ["CIRRUS_OS"]
-    if os == "windows":
+    if os == "Windows":
         file = base + "/install.ps1"
         cmd = "iex ((New-Object System.Net.WebClient).DownloadString('%s'))" % file
         return powershell("install", cmd)
     file = base + "/install.sh"
-    if os == "darwin":
+    if os == "macOS":
         download = "curl " + file
-    elif os == "freebsd":
+    elif os == "FreeBSD":
         download = "fetch %s -o -" % file
     else:
         download = "wget %s -q -O-" % file
     cmd = "sh -c \"$(%s)\"" % download
     return script("install", cmd)
 
-def julia_instructions(coverage=None):
-    steps = [cirrusjl_install(),
+def julia_instructions(os, coverage=None):
+    steps = [cirrusjl_install(os),
              script("build", "cirrusjl build"),
              script("test", "cirrusjl test")]
     if coverage:
@@ -28,10 +41,11 @@ def julia_instructions(coverage=None):
 
 def julia_tasks(versions, instances, env={}, coverage=None, allow_failures=None):
     tasks = []
-    instructions = julia_instructions(coverage=coverage)
     for instance in instances:
+        os = _os_from_instance(instance)
+        instructions = julia_instructions(os, coverage=coverage)
         for version in versions:
             v = {"JULIA_VERSION": version}.update(env)
-            t = task(name="", instance=instance, instructions=instructions, env=v)
+            t = task(name=os, instance=instance, instructions=instructions, env=v)
             tasks.append(t)
     return tasks

--- a/test/cirrusjl_install/.cirrus.expected.yml
+++ b/test/cirrusjl_install/.cirrus.expected.yml
@@ -1,19 +1,23 @@
 task:
   name: FreeBSD
   freebsd_instance:
-    image: freebsd-13-0-release-amd64
+    image_family: freebsd-13-0
   install_script:
     - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
 task:
   name: Linux AArch64
   arm_container:
     image: ubuntu:latest
+    cpu: 2
+    memory: 4096
   install_script:
     - sh -c "$(wget https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -q -O-)"
 task:
   name: Linux musl
   container:
     image: alpine:3.14
+    cpu: 2
+    memory: 4096
   install_script:
     - sh -c "$(wget https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -q -O-)"
 task:

--- a/test/cirrusjl_install/.cirrus.expected.yml
+++ b/test/cirrusjl_install/.cirrus.expected.yml
@@ -1,0 +1,30 @@
+task:
+  name: FreeBSD
+  freebsd_instance:
+    image: freebsd-13-0-release-amd64
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+task:
+  name: Linux AArch64
+  arm_container:
+    image: ubuntu:latest
+  install_script:
+    - sh -c "$(wget https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -q -O-)"
+task:
+  name: Linux musl
+  container:
+    image: alpine:3.14
+  install_script:
+    - sh -c "$(wget https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -q -O-)"
+task:
+  name: Windows
+  windows_container:
+    image: cirrusci/windowsservercore
+  install_script:
+    - ps: iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.ps1'))
+task:
+  name: macOS
+  macos_instance:
+    image: big-sur-xcode
+  install_script:
+    - sh -c "$(curl https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh)"

--- a/test/cirrusjl_install/.cirrus.star
+++ b/test/cirrusjl_install/.cirrus.star
@@ -1,0 +1,13 @@
+load("../../lib.star", "cirrusjl_install")
+load("github.com/cirrus-modules/helpers", "task", "windows_container", "freebsd_instance",
+     "macos_instance", "container", "arm_container")
+
+def _task(name, instance):
+    return task(name, instance, instructions=[cirrusjl_install()])
+
+def main(ctx):
+    return [_task("FreeBSD", freebsd_instance("freebsd-13-0-release-amd64")),
+            _task("Linux AArch64", arm_container("ubuntu:latest")),
+            _task("Linux musl", container("alpine:3.14")),
+            _task("Windows", windows_container("cirrusci/windowsservercore")),
+            _task("macOS", macos_instance("big-sur-xcode"))]

--- a/test/cirrusjl_install/.cirrus.star
+++ b/test/cirrusjl_install/.cirrus.star
@@ -3,7 +3,8 @@ load("github.com/cirrus-modules/helpers", "task", "windows_container", "freebsd_
      "macos_instance", "container", "arm_container")
 
 def _task(name, instance):
-    return task(name, instance, instructions=[cirrusjl_install()])
+    os = name.split(" ")[0]
+    return task(name, instance, instructions=[cirrusjl_install(os)])
 
 def main(ctx):
     return [_task("FreeBSD", freebsd_instance("freebsd-13-0-release-amd64")),

--- a/test/cirrusjl_install/.cirrus.star
+++ b/test/cirrusjl_install/.cirrus.star
@@ -7,7 +7,7 @@ def _task(name, instance):
     return task(name, instance, instructions=[cirrusjl_install(os)])
 
 def main(ctx):
-    return [_task("FreeBSD", freebsd_instance("freebsd-13-0-release-amd64")),
+    return [_task("FreeBSD", freebsd_instance("freebsd-13-0")),
             _task("Linux AArch64", arm_container("ubuntu:latest")),
             _task("Linux musl", container("alpine:3.14")),
             _task("Windows", windows_container("cirrusci/windowsservercore")),

--- a/test/julia_instructions/.cirrus.expected.yml
+++ b/test/julia_instructions/.cirrus.expected.yml
@@ -1,0 +1,22 @@
+task:
+  name: No coverage
+  freebsd_instance:
+    image_family: freebsd-13-0
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - cirrusjl test
+task:
+  name: Codecov
+  freebsd_instance:
+    image_family: freebsd-13-0
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - cirrusjl test
+  coverage_script:
+    - cirrusjl coverage codecov

--- a/test/julia_instructions/.cirrus.star
+++ b/test/julia_instructions/.cirrus.star
@@ -1,0 +1,8 @@
+load("../../lib.star", "julia_instructions")
+load("github.com/cirrus-modules/helpers", "task", "freebsd_instance")
+
+def main(ctx):
+    return [task("No coverage", freebsd_instance("freebsd-13-0"),
+                 instructions=julia_instructions("FreeBSD")),
+            task("Codecov", freebsd_instance("freebsd-13-0"),
+                 instructions=julia_instructions("FreeBSD", coverage="codecov"))]


### PR DESCRIPTION
Cirrus gives you the option to use .cirrus.star files that can load external Starlark modules to provide various pieces of functionality for testing on Cirrus. Gonna give this a try since hopefully it will make cross-platform support a bit easier but also I don't really know what I'm doing.