### PR TITLE
Use the Codecov CLI rather than the legacy uploader

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,12 +15,12 @@ task:
         - JULIA_VERSION: 1
     - name: musl Linux
       container:
-        image: alpine:3.14
+        image: alpine:latest
       env:
         - JULIA_VERSION: 1
     - name: macOS M1
       macos_instance:
-        image: ghcr.io/cirruslabs/macos-monterey-base:latest
+        image: ghcr.io/cirruslabs/macos-sonoma-base:latest
       env:
         - JULIA_VERSION: 1
   allow_failures: $JULIA_VERSION == 'nightly'

--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ task:
           - JULIA_VERSION: nightly
     - name: Linux musl
       container:
-        image: alpine:3.14
+        image: alpine:latest
       env:
         - JULIA_VERSION: 1
     - name: macOS M1
       macos_instance:
-        image: ghcr.io/cirruslabs/macos-monterey-base:latest
+        image: ghcr.io/cirruslabs/macos-sonoma-base:latest
       env:
         - JULIA_VERSION: 1
   allow_failures: $JULIA_VERSION == 'nightly'
@@ -147,12 +147,16 @@ task:
 ### Code Coverage
 
 Collection of code coverage is supported on all platforms.
-However, submission of coverage information to [Codecov](https://codecov.io) is not
-supported on FreeBSD due to [limitations](https://github.com/codecov/uploader/issues/849)
-in Codecov's uploader.
-Coverage submission is skipped on FreeBSD without affecting the build status.
-Submission of coverage information to [Coveralls](https://coveralls.io) is currently
-unsupported, though requesting it will similarly not affect the build status.
+Submission of coverage information to [Codecov](https://codecov.io) is supported using
+Codecov's official command line interface, which should theoretically work on any platform.
+Submission to [Coveralls](https://coveralls.io) is not supported, but requesting it does
+not affect the build status.
+
+> [!NOTE]
+> `cirrusjl coverage codecov` can be very slow on FreeBSD because it needs to compile the
+> Codecov CLI from source in every run. I've seen this take roughly 6-7 minutes. Most
+> other platforms can use Codecov's prebuilt binaries, in which case this step takes just
+> a few seconds.
 
 ### Projects in Subdirectories
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -35,11 +35,13 @@ if [ "${OS}" = "freebsd" ]; then
 elif [ "${OS}" = "musl" ]; then
     INSTALLER="apk"
     INSTALL_CMD="add"
-elif [ "${OS}" != "mac" ] && [ ! -z "$(which apt)" ]; then
-    INSTALLER="apt"
-    INSTALL_CMD="install -y"
-else
-    stop "Please open an issue on https://github.com/ararslan/CirrusCI.jl and tell me how to install system packages on this OS"
+elif [ "${OS}" != "mac" ]
+    if [ ! -z "$(which apt)" ]; then
+        INSTALLER="apt"
+        INSTALL_CMD="install -y"
+    else
+        stop "Please open an issue on https://github.com/ararslan/CirrusCI.jl and tell me how to install system packages on this OS"
+    fi
 fi
 
 install() {
@@ -282,6 +284,8 @@ case "\${INPUT}" in
                 if [ -z "\$(which gcc)" ]; then
                     _install build-base
                 fi
+            elif [ "${OS}" = "linux" ] && [ -z "\$(which gcc)" ]; then
+                _install gcc
             elif [ "${OS}" = "freebsd" ]; then
                 _install rust
             fi

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -35,7 +35,7 @@ if [ "${OS}" = "freebsd" ]; then
 elif [ "${OS}" = "musl" ]; then
     INSTALLER="apk"
     INSTALL_CMD="add"
-elif [ "${OS}" != "mac" ]
+elif [ "${OS}" != "mac" ]; then
     if [ ! -z "$(which apt)" ]; then
         INSTALLER="apt"
         INSTALL_CMD="install -y"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -303,6 +303,7 @@ case "\${INPUT}" in
                 --verbose \
                 upload-process \
                     --commit-sha="\${CIRRUS_CHANGE_IN_REPO}" \
+                    --git-service github \
                     --file lcov.info
             deactivate
         fi

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -272,10 +272,22 @@ case "\${INPUT}" in
                 echo "Installing Python for Codecov CLI"
                 ${INSTALLER} ${INSTALL_CMD} python3
             fi
-            python3 -m ensurepip
-            python3 -m pip install --upgrade pip
+            # Evidently some platforms need to compile C/C++ and/or Rust code??
+            if [ "${OS}" = "musl" ] && [ -z "\$(which gcc)" ]; then
+                ${INSTALLER} ${INSTALL_CMD} build-base
+            elif [ "${OS}" = "freebsd" ]; then
+                ${INSTALLER} ${INSTALL_CMD} rust
+            fi
             echo "Installing Codecov CLI"
-            python3 -m pip install codecov-cli
+            # Why, Ubuntu
+            if [ "\$(python3 -c 'import importlib.util; print(importlib.util.find_spec("ensurepip"))')" = "None" ]; then
+                ${INSTALLER} ${INSTALL_CMD} python3-pip
+                pip3 install codecov-cli
+            else
+                python3 -m ensurepip
+                python3 -m pip install --upgrade pip
+                python3 -m pip install codecov-cli
+            fi
             echo "Submitting to Codecov"
             codecovcli upload-process --file lcov.info --verbose
         fi

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -284,7 +284,7 @@ case "\${INPUT}" in
                 if [ -z "\$(which gcc)" ]; then
                     _install build-base
                 fi
-            elif [ "${OS}" = "linux" ] && [ -z "\$(which gcc)" ]; then
+            elif [ "${OS}" = "linux" ] && [ "${ARCH}" != "x86_64" ] && [ -z "\$(which gcc)" ]; then
                 _install gcc
             elif [ "${OS}" = "freebsd" ]; then
                 _install rust

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -159,16 +159,19 @@ fi
 
 ### Install and verify Julia
 
-if [ ! -d /usr/local/bin ]; then
+DESTDIR="/usr/local/bin"
+
+if [ ! -w ${DESTDIR} ]; then
     # Some images don't have this directory by default and the default user isn't root,
     # which means we need `sudo` to install to `/usr/local/bin`, assuming `sudo` is
     # available. Empirically, these conditions seems only to be the case on macOS.
     if [ $(id -u) -ne 0 ] && [ ! -z "$(command -v sudo)" ]; then
-        sudo mkdir -p /usr/local/bin
-        sudo chown -R $(id -un) /usr/local/bin
+        SUDO="sudo"
     else
-        mkdir -p /usr/local/bin
+        SUDO=""
     fi
+    [ -d ${DESTDIR} ] || ${SUDO} mkdir -p ${DESTDIR}
+    ${SUDO} chown -R $(id -un) ${DESTDIR}
 fi
 
 ln -fs "${HOME}/julia/bin/julia" /usr/local/bin/julia
@@ -180,7 +183,7 @@ julia --color=yes -e "using InteractiveUtils; versioninfo()"
 # Throw out trailing .jl, assume the name is otherwise a valid Julia package name
 JLPKG="$(basename "${CIRRUS_REPO_NAME}/${JULIA_PROJECT_SUBDIR}" | cut -d'.' -f 1)"
 
-cat > /usr/local/bin/cirrusjl <<EOF
+cat > "${DESTDIR}/cirrusjl" <<EOF
 #!/bin/sh
 
 set -e


### PR DESCRIPTION
The Codecov CLI is a Python package that should hopefully work uniformly across operating systems, unlike the Node.js based legacy uploader.

May possibly close #21 🤞